### PR TITLE
Add ml-quant-trading to systematic frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Institutional edges are rigorously backtested. These frameworks allow traders to
 | [NautilusTrader](https://nautilustrader.io/) | Rust / Python | Open-source, ultra-high-performance algorithmic trading platform. Designed for HFT and institutional-grade event-driven backtesting. |
 | [QuantConnect](https://www.quantconnect.com/) | C# / Python | Cloud-based algorithmic trading engine with massive built-in institutional datasets (tick, fundamental, alternative). |
 | [Backtrader](https://www.backtrader.com/) | Python | The most widely used open-source Python backtesting framework. Excellent for prototyping systematic strategies. |
+| [ml-quant-trading](https://github.com/initial-d/ml-quant-trading) | Python / PyTorch | Research-oriented multi-factor pipeline with mask-first handling of non-tradable observations, portfolio optimization, and vectorized backtesting. |
 
 ### Pine Script & Custom Tooling
 


### PR DESCRIPTION
## What changed

Adds `ml-quant-trading` to the Systematic & Algorithmic Trading framework table using the existing three-column format.

## Why it fits

The project is an MIT-licensed, research-oriented Python/PyTorch stack for multi-factor modeling. Its mask-first treatment of limit-up, limit-down, halted, and missing observations supports the list's emphasis on data-driven methodology and avoiding unrealistic backtests. It also includes portfolio optimization and vectorized backtesting.

## Impact

Readers gain another open-source research framework focused on cross-sectional factor pipelines. The entry is objective and makes no profitability or live-trading claims.

## Validation

- Confirmed the project is not already listed.
- Matched the existing Markdown table format and category.
- Ran `git diff --check` and verified the repository link.

## Disclosure

I maintain `initial-d/ml-quant-trading` and authored its accompanying paper; this is a transparent self-submission.
